### PR TITLE
Add support for extended regexpressions to grep().

### DIFF
--- a/span/span.py
+++ b/span/span.py
@@ -791,11 +791,11 @@ class RefPolicySource(object):
         self.abspath = os.path.abspath(self.path)
         self.modules_path = self.path + "/policy/modules"
 
-    def grep(self, search_str, file_type, path=None):
+    def grep(self, search_str, file_type, path=None, extended=False):
         if path is None:
             path = self.path
-        return subprocess.run(["grep", "-r", "-n", "--include",
-                               file_type, search_str, "."], cwd=path, stdout=subprocess.PIPE,
+        return subprocess.run(["grep", "-r", "-n" ] + [ "--extended-regexp" ] * extended +
+                              [ "--include", file_type, search_str, "."], cwd=path, stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT).stdout.decode('utf-8')
 
     def diff(self, patha, pathb):
@@ -814,8 +814,8 @@ class RefPolicySource(object):
     def attr_def(self, name):
         return self.find_def("attribute " + name)
 
-    def file_contexts(self, type_name):
-        return self.grep(type_name, "*.fc", self.modules_path)
+    def file_contexts(self, type_name, extended=False):
+        return self.grep(type_name, "*.fc", self.modules_path, extended)
 
     def genfscon(self, fs_type):
         return self.find_def("genfscon " + fs_type)


### PR DESCRIPTION
Add an `extended` keyword argument for `grep()`. When set to `True`,
it passes `--extended-regex` to the grep command so you
can do searches using expressions like `(console_device_t|devtty_t)`.